### PR TITLE
fix duplicated read issue if there are multiple parquet files

### DIFF
--- a/src/main/java/com/example/pxf/DeltaTableAccessor.java
+++ b/src/main/java/com/example/pxf/DeltaTableAccessor.java
@@ -72,7 +72,7 @@ public class DeltaTableAccessor extends BasePlugin implements org.greenplum.pxf.
             try {
                 String filePath = fileIterator.next();
                 LOG.info("Processing file: " + filePath);
-                rowIterator = snapshot.open(); // Open the iterator for the current file
+                rowIterator = snapshot.open(); // Open the iterator for the whole Delta table
                 return true;
             } catch (Exception e) {
                 LOG.log(Level.SEVERE, "Error opening file for reading rows", e);
@@ -87,8 +87,6 @@ public class DeltaTableAccessor extends BasePlugin implements org.greenplum.pxf.
             if (rowIterator != null && rowIterator.hasNext()) {
                 RowRecord row = rowIterator.next();
                 return new OneRow(null, extractRowValues(row, fields));
-            } else if (openNextFile()) {
-                return readNextObject(); // Recursively process the next file
             }
         } catch (Exception e) {
             LOG.log(Level.SEVERE, "Error reading next object", e);

--- a/src/main/java/com/example/pxf/DeltaTableFragmenter.java
+++ b/src/main/java/com/example/pxf/DeltaTableFragmenter.java
@@ -43,8 +43,6 @@ public class DeltaTableFragmenter extends BaseFragmenter {
         List<Fragment> fragments = new ArrayList<>();
         try {
             Snapshot snapshot = deltaLog.snapshot();
-            List<AddFile> allFiles = snapshot.getAllFiles();
-            int totalFiles = allFiles.size();
 
             // Get total segments from PXF context or default to 8
             int totalSegments = context.getTotalSegments();
@@ -54,17 +52,8 @@ public class DeltaTableFragmenter extends BaseFragmenter {
             }
 
 	    LOG.info("Starting fragment assignment.");
-	    LOG.info("Total files available: " + totalFiles);
-            LOG.info("Total segments configured: " + totalSegments);
-	    for (int i = 0; i < totalFiles; i++) {
-		AddFile file = allFiles.get(i);
-    		String filePath = file.getPath();
-    		int assignedSegment = i % totalSegments;
-    		LOG.info("Assigning file: " + filePath + " to segment: " + assignedSegment);
-    		DeltaFragmentMetadata metadata = new DeltaFragmentMetadata(filePath, assignedSegment, totalSegments, null);
-    		fragments.add(new Fragment(context.getDataSource(), metadata, null));
-	    }
-
+            DeltaFragmentMetadata metadata = new DeltaFragmentMetadata(context.getDataSource(), 0, totalSegments, null);
+            fragments.add(new Fragment(context.getDataSource(), metadata, null));
 	    LOG.info("Completed fragment assignment.");
             LOG.info("Total fragments created: " + fragments.size());
 


### PR DESCRIPTION
Root cause:
     For normal Fragmenter, it will return `min(N, gp_seg_num)` fragments if there are N parquet files in Delta table. But each Fragmenter will return the full data of table.
     The accessor will call `snapshot.open()` for N times if there are N parquet files. But each `snapshot.open()` will return the whole data of table. refer to [delta table java API](https://docs.delta.io/latest/api/java/standalone/index.html?io/delta/standalone/Snapshot.html)
     
Solution:
    1. Return only one segment for each table
    2. Don't check the files number to be read if use `snapshot.open()`
 
Todo:
    It should be better to read the parquet files in parallel, but we need use the low level API to access. `snapshot.scan(Expression predicate)` can filter the data. need further survey.