### PR TITLE
Read Delta table using kernel API for delta plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,16 @@ Update the `pxf-profiles.xml` file located at `$PXF_BASE/conf` to include the De
             <resolver>com.example.pxf.DeltaTableResolver</resolver>
         </plugins>
     </profile>
-</profiles>
 
-	<profile>
+    <profile>
         <name>deltavec</name>
         <plugins>
             <fragmenter>com.example.pxf.DeltaPartitionFragmenter</fragmenter>
 	    <accessor>com.example.pxf.DeltaTableVectorizedAccessor</accessor>
 	    <resolver>com.example.pxf.DeltaTableVectorizedResolver</resolver>
         </plugins>
-</profile>
-
-
+    </profile>
+</profiles>
 
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,8 @@
     <groupId>org.greenplum.pxf</groupId>
     <artifactId>pxf-hdfs</artifactId>
     <version>6.11.0-SNAPSHOT</version>
+    <scope>system</scope>
+    <systemPath>${project.basedir}/lib/pxf-hdfs-6.11.0-SNAPSHOT.jar</systemPath>
 </dependency>
 
 <dependency>
@@ -83,6 +85,8 @@
             <groupId>io.delta</groupId>
             <artifactId>delta-standalone</artifactId>
             <version>3.3.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/delta-standalone-3.3.0.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>io.delta</groupId>

--- a/src/main/java/com/example/pxf/DeltaPartitionFragmenter.java
+++ b/src/main/java/com/example/pxf/DeltaPartitionFragmenter.java
@@ -6,7 +6,6 @@ import org.greenplum.pxf.api.model.FragmentStats;
 import com.example.pxf.partitioning.DeltaVectorizedFragmentMetadata;
 
 import java.io.*;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;


### PR DESCRIPTION
Change Delta table API from standalone to kernel, because:
1. Standalone API can't read files in parallel.
2.Standalone API is deprecated, refer to [link](https://docs.delta.io/latest/delta-standalone.html#)

Then we can assign each file/partition to a Fragment, and GPDB segments will handle the Fragments in parallel.

Todo:
Modify deltavec plugin based kernel API too