### PR TITLE
Support column projection and predicate pushdown for delta table

### DIFF
--- a/src/main/java/com/example/pxf/DeltaTableAccessor.java
+++ b/src/main/java/com/example/pxf/DeltaTableAccessor.java
@@ -83,6 +83,7 @@ public class DeltaTableAccessor extends BasePlugin implements org.greenplum.pxf.
             snapshot = deltaTable.getLatestSnapshot(engine);
             ScanBuilder scanBuilder = snapshot.getScanBuilder(engine);
             StructType readSchema = DeltaUtilities.getReadSchema(context.getTupleDescription());
+            readSchema.fields().forEach(f -> LOG.info("Field: " + f.getName() + " Type: " + f.getDataType()));
             scanBuilder = scanBuilder.withReadSchema(engine, readSchema);
             scan = scanBuilder.build();
 

--- a/src/main/java/com/example/pxf/DeltaTableAccessor.java
+++ b/src/main/java/com/example/pxf/DeltaTableAccessor.java
@@ -78,9 +78,13 @@ public class DeltaTableAccessor extends BasePlugin implements org.greenplum.pxf.
                 }
             }
             LOG.info("Opening DeltaLog for table path: " + tablePath);
+
             Table deltaTable = Table.forPath(engine, tablePath);
             snapshot = deltaTable.getLatestSnapshot(engine);
-            scan = snapshot.getScanBuilder(engine).build();
+            ScanBuilder scanBuilder = snapshot.getScanBuilder(engine);
+            StructType readSchema = DeltaUtilities.getReadSchema(context.getTupleDescription());
+            scanBuilder = scanBuilder.withReadSchema(engine, readSchema);
+            scan = scanBuilder.build();
 
             scanState = scan.getScanState(engine);
             scanFileIter = scan.getScanFiles(engine);
@@ -197,7 +201,7 @@ public class DeltaTableAccessor extends BasePlugin implements org.greenplum.pxf.
                         "pxf", /* engineInfo */
                         Operation.CREATE_TABLE);
 
-            tableSchema = generateParquetSchema(context.getTupleDescription());
+            tableSchema = DeltaUtilities.generateParquetSchema(context.getTupleDescription());
             if (!DeltaUtilities.isDeltaTable(tablePath)) {
                 // Set the schema of the NEW table on the transaction builder
                 txnBuilder = txnBuilder.withSchema(engine, tableSchema);
@@ -217,63 +221,6 @@ public class DeltaTableAccessor extends BasePlugin implements org.greenplum.pxf.
         createTransaction(tablePath);
 
         return true;
-    }
-
-    /**
-     * Generate schema for all the supported types using column descriptors
-     *
-     * @param columns contains Greenplum data type and column name
-     * @return the generated parquet schema used for write
-     */
-    private StructType generateParquetSchema(List<ColumnDescriptor> columns) {
-        StructType schema = new StructType();
-        for (ColumnDescriptor column : columns) {
-            schema = schema.add(column.columnName(), getTypeForColumnDescriptor(column));
-            LOG.info("Added column: " + column.columnName() + " with type: " + column.columnTypeName());
-        }
-        return schema;
-    }
-
-    /**
-     * Get the corresponding Parquet type for the given Greenplum column descriptor
-     *
-     * @param columnDescriptor contains Greenplum data type and column name
-     * @return the corresponding Parquet type
-     */
-    private DataType getTypeForColumnDescriptor(ColumnDescriptor columnDescriptor) {
-        String typeName = columnDescriptor.columnTypeName();
-        switch (typeName.toLowerCase()) {
-            case "boolean":
-                return BooleanType.BOOLEAN;
-            case "bytea":
-                return ByteType.BYTE;
-            case "bigint":
-            case "int8":
-                return LongType.LONG;
-            case "integer":
-            case "int4":
-                return IntegerType.INTEGER;
-            case "smallint":
-            case "int2":
-                return ShortType.SHORT;
-            case "real":
-            case "float":
-            case "float4":
-                return FloatType.FLOAT;
-            case "float8":
-                return DoubleType.DOUBLE;
-            case "date":
-                return DateType.DATE;
-            case "timestamp":
-                return TimestampType.TIMESTAMP;
-            case "text":
-            case "varchar":
-            case "bpchar":
-            case "numeric":             // Greenplum numeric type is mapped to string type now
-                return StringType.STRING;
-            default:
-                throw new UnsupportedOperationException("Unsupported data type: " + typeName);
-        }
     }
 
     private void verifyCommitSuccess(String tablePath, TransactionCommitResult result) {

--- a/src/main/java/com/example/pxf/DeltaTableResolver.java
+++ b/src/main/java/com/example/pxf/DeltaTableResolver.java
@@ -139,14 +139,13 @@ public List<OneField> getFields(OneRow row) {
     // Extract fields based on the schema
     List<OneField> fields = new ArrayList<>();
     for (ColumnDescriptor column : context.getTupleDescription()) {
-        String columnName = column.columnName();
-        Object value = extractValue(record, columnName, schema);
-
-        OneField oneField = new OneField();
-        oneField.type = column.getDataType().getOID();
-        oneField.val = value;
-
-        fields.add(oneField);
+        if (column.isProjected()) {
+            String columnName = column.columnName();
+            Object value = extractValue(record, columnName, schema);
+            fields.add(new OneField(column.getDataType().getOID(), value));
+        } else {
+            fields.add(new OneField(column.getDataType().getOID(), null));
+        }
     }
 
     return fields;

--- a/src/main/java/com/example/pxf/DeltaTableVectorizedAccessor.java
+++ b/src/main/java/com/example/pxf/DeltaTableVectorizedAccessor.java
@@ -128,7 +128,9 @@ public class DeltaTableVectorizedAccessor extends BasePlugin implements Accessor
 
         recordFilter = DeltaUtilities.getFilterPredicate(context.getFilterString(), readSchema, context.getTupleDescription());
         LOG.info("Filter predicate: " + recordFilter);
-        scanBuilder = scanBuilder.withFilter(engine, recordFilter);
+        if (recordFilter != null) {
+            scanBuilder = scanBuilder.withFilter(engine, recordFilter);
+        }
         scan = scanBuilder.build();
         scanState = scan.getScanState(engine);
         scanFileIter = scan.getScanFiles(engine);

--- a/src/main/java/com/example/pxf/DeltaTableVectorizedFragmenter.java
+++ b/src/main/java/com/example/pxf/DeltaTableVectorizedFragmenter.java
@@ -77,7 +77,6 @@ public class DeltaTableVectorizedFragmenter extends BaseFragmenter {
                         String partitionInfo = extractPartitionInfo(file.getPath(), partitionColumns);
                         DeltaVectorizedFragmentMetadata metadata = new DeltaVectorizedFragmentMetadata(file.getPath(), partitionInfo);
                         Fragment fragment = new Fragment(context.getDataSource(), metadata, null);
-                        fragment.setSegmentId(0);
                         fragments.add(fragment);
                     });
                 } else {

--- a/src/main/java/com/example/pxf/DeltaTableVectorizedFragmenter.java
+++ b/src/main/java/com/example/pxf/DeltaTableVectorizedFragmenter.java
@@ -76,14 +76,16 @@ public class DeltaTableVectorizedFragmenter extends BaseFragmenter {
                     snapshot.getAllFiles().forEach(file -> {
                         String partitionInfo = extractPartitionInfo(file.getPath(), partitionColumns);
                         DeltaVectorizedFragmentMetadata metadata = new DeltaVectorizedFragmentMetadata(file.getPath(), partitionInfo);
-                        fragments.add(new Fragment(context.getDataSource(), metadata, null));
+                        Fragment fragment = new Fragment(context.getDataSource(), metadata, null);
+                        fragment.setSegmentId(0);
+                        fragments.add(fragment);
                     });
                 } else {
                     LOG.info("Fragmenting based on file splits...");
                     snapshot.getAllFiles().forEach(file -> {
                         DeltaVectorizedFragmentMetadata metadata = new DeltaVectorizedFragmentMetadata(file.getPath(), null);
-                        fragments.add(new Fragment(context.getDataSource(), metadata, null));
-                    });
+                        Fragment fragment = new Fragment(context.getDataSource(), metadata, null);
+                        fragments.add(fragment);                    });
                 }
         }
         } catch (Exception e) {

--- a/src/main/java/com/example/pxf/DeltaTableVectorizedResolver.java
+++ b/src/main/java/com/example/pxf/DeltaTableVectorizedResolver.java
@@ -97,9 +97,13 @@ public class DeltaTableVectorizedResolver implements ReadVectorizedResolver, Wri
         int i = 0;
 
         for (ColumnDescriptor column : tupleDescription) {
-            Object value = extractValue(row, i);
-            fields.add(new OneField(column.getDataType().getOID(), value));
-            i++;
+            if (column.isProjected()) {
+                Object value = extractValue(row, i);
+                fields.add(new OneField(column.getDataType().getOID(), value));
+                i++;
+            } else {
+                fields.add(new OneField(column.getDataType().getOID(), null));
+            }
         }
 
         return fields;

--- a/src/main/java/com/example/pxf/DeltaTableVectorizedResolver.java
+++ b/src/main/java/com/example/pxf/DeltaTableVectorizedResolver.java
@@ -78,15 +78,10 @@ public class DeltaTableVectorizedResolver implements ReadVectorizedResolver, Wri
 
         LOG.fine(String.format("Processing batch of %d rows", records.size()));
 
-        final Instant start = Instant.now();
-
         List<List<OneField>> resolvedBatch = new ArrayList<>(records.size());
         for (Row record : records) {
             resolvedBatch.add(processRecord(record));
         }
-
-        final long elapsedMillis = Duration.between(start, Instant.now()).toMillis();
-        LOG.info(String.format("Processed batch of %d rows in %d milliseconds", records.size(), elapsedMillis));
 
         return resolvedBatch;
     }

--- a/src/main/java/com/example/pxf/DeltaUtilities.java
+++ b/src/main/java/com/example/pxf/DeltaUtilities.java
@@ -27,7 +27,7 @@ import com.example.pxf.parquet.ParquetRecordFilterBuilder;
 import org.greenplum.pxf.api.filter.TreeTraverser;
 
 public class DeltaUtilities {
-    private static final Logger LOG = Logger.getLogger(DeltaTableFragmenter.class.getName());
+    private static final Logger LOG = Logger.getLogger(DeltaUtilities.class.getName());
     private static final TreeTraverser TRAVERSER = new TreeTraverser();
     private static final TreeVisitor IN_OPERATOR_TRANSFORMER = new InOperatorTransformer();
 
@@ -187,9 +187,12 @@ public class DeltaUtilities {
         }
     }
 
-    public static StructType getReadSchema(List<ColumnDescriptor> columns) {
+    public static StructType getReadSchema(List<ColumnDescriptor> columns, List<String> partitionColumns) {
         StructType schema = new StructType();
         for (ColumnDescriptor column : columns) {
+            if (partitionColumns.contains(column.columnName())) {
+                column.setProjected(true);
+            }
             if (column.isProjected()) { // Skip columns that are not projected
                 schema = schema.add(column.columnName(), getTypeForColumnDescriptor(column));
                 LOG.info("Added column: " + column.columnName() + " with type: " + column.columnTypeName());
@@ -207,7 +210,7 @@ public class DeltaUtilities {
         StructType schema = new StructType();
         for (ColumnDescriptor column : columns) {
             schema = schema.add(column.columnName(), getTypeForColumnDescriptor(column));
-            LOG.info("Added column: " + column.columnName() + " with type: " + column.columnTypeName());
+            LOG.info("Added parquet column: " + column.columnName() + " with type: " + column.columnTypeName());
         }
         return schema;
     }

--- a/src/main/java/com/example/pxf/DeltaUtilities.java
+++ b/src/main/java/com/example/pxf/DeltaUtilities.java
@@ -2,6 +2,9 @@ package com.example.pxf;
 
 import java.io.File;
 import java.util.logging.Logger;
+import java.util.List;
+import io.delta.kernel.types.*;
+import org.greenplum.pxf.api.utilities.ColumnDescriptor;
 
 public class DeltaUtilities {
     private static final Logger LOG = Logger.getLogger(DeltaTableFragmenter.class.getName());
@@ -29,5 +32,72 @@ public class DeltaUtilities {
             }
         }
         return true;
+    }
+
+    /**
+     * Get the corresponding Parquet type for the given Greenplum column descriptor
+     *
+     * @param columnDescriptor contains Greenplum data type and column name
+     * @return the corresponding Parquet type
+     */
+    private static DataType getTypeForColumnDescriptor(ColumnDescriptor columnDescriptor) {
+        String typeName = columnDescriptor.columnTypeName();
+        switch (typeName.toLowerCase()) {
+            case "boolean":
+                return BooleanType.BOOLEAN;
+            case "bytea":
+                return ByteType.BYTE;
+            case "bigint":
+            case "int8":
+                return LongType.LONG;
+            case "integer":
+            case "int4":
+                return IntegerType.INTEGER;
+            case "smallint":
+            case "int2":
+                return ShortType.SHORT;
+            case "real":
+            case "float":
+            case "float4":
+                return FloatType.FLOAT;
+            case "float8":
+                return DoubleType.DOUBLE;
+            case "date":
+                return DateType.DATE;
+            case "timestamp":
+                return TimestampType.TIMESTAMP;
+            case "text":
+            case "varchar":
+            case "bpchar":
+            case "numeric":             // Greenplum numeric type is mapped to string type now
+                return StringType.STRING;
+            default:
+                throw new UnsupportedOperationException("Unsupported data type: " + typeName);
+        }
+    }
+
+    public static StructType getReadSchema(List<ColumnDescriptor> columns) {
+        StructType schema = new StructType();
+        for (ColumnDescriptor column : columns) {
+            if (column.isProjected()) { // Skip columns that are not projected
+                schema = schema.add(column.columnName(), getTypeForColumnDescriptor(column));
+                LOG.info("Added column: " + column.columnName() + " with type: " + column.columnTypeName());
+            }
+        }
+        return schema;
+    }
+   /**
+     * Generate schema for all the supported types using column descriptors
+     *
+     * @param columns contains Greenplum data type and column name
+     * @return the generated parquet schema used for write
+     */
+    public static StructType generateParquetSchema(List<ColumnDescriptor> columns) {
+        StructType schema = new StructType();
+        for (ColumnDescriptor column : columns) {
+            schema = schema.add(column.columnName(), getTypeForColumnDescriptor(column));
+            LOG.info("Added column: " + column.columnName() + " with type: " + column.columnTypeName());
+        }
+        return schema;
     }
 }

--- a/src/main/java/com/example/pxf/DeltaUtilities.java
+++ b/src/main/java/com/example/pxf/DeltaUtilities.java
@@ -2,12 +2,32 @@ package com.example.pxf;
 
 import java.io.File;
 import java.util.logging.Logger;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
 import io.delta.kernel.types.*;
+import io.delta.kernel.expressions.*;
+
+import org.greenplum.pxf.api.filter.FilterParser;
+import org.greenplum.pxf.api.filter.InOperatorTransformer;
+import org.greenplum.pxf.api.filter.Node;
+import org.greenplum.pxf.api.filter.TreeVisitor;
 import org.greenplum.pxf.api.utilities.ColumnDescriptor;
+import org.greenplum.pxf.plugins.hdfs.filter.BPCharOperatorTransformer;
+import org.greenplum.pxf.plugins.hdfs.parquet.ParquetOperatorPruner;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Types;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Type.Repetition;
+import com.example.pxf.parquet.ParquetRecordFilterBuilder;
+import org.greenplum.pxf.api.filter.TreeTraverser;
 
 public class DeltaUtilities {
     private static final Logger LOG = Logger.getLogger(DeltaTableFragmenter.class.getName());
+    private static final TreeTraverser TRAVERSER = new TreeTraverser();
+    private static final TreeVisitor IN_OPERATOR_TRANSFORMER = new InOperatorTransformer();
 
     public static boolean isDeltaTable(String tablePath) {
         // check the tablePath/_delta_log directory exists
@@ -73,6 +93,95 @@ public class DeltaUtilities {
                 return StringType.STRING;
             default:
                 throw new UnsupportedOperationException("Unsupported data type: " + typeName);
+        }
+    }
+
+    private static Type dataTypeToParquetType(DataType dataType) {
+        switch (dataType.toString().toUpperCase()) {
+            case "BOOLEAN":
+                return Types.primitive(PrimitiveTypeName.BOOLEAN, Repetition.OPTIONAL).named("boolean");
+            case "BYTE":
+                return Types.primitive(PrimitiveTypeName.INT32, Repetition.OPTIONAL).named("byte");
+            case "LONG":
+                return Types.primitive(PrimitiveTypeName.INT64, Repetition.OPTIONAL).named("long");
+            case "INTEGER":
+                return Types.primitive(PrimitiveTypeName.INT32, Repetition.OPTIONAL).named("integer");
+            case "SHORT":
+                return Types.primitive(PrimitiveTypeName.INT32, Repetition.OPTIONAL).named("short");
+            case "FLOAT":
+                return Types.primitive(PrimitiveTypeName.FLOAT, Repetition.OPTIONAL).named("float");
+            case "DOUBLE":
+                return Types.primitive(PrimitiveTypeName.DOUBLE, Repetition.OPTIONAL).named("double");
+            case "DATE":
+                return Types.primitive(PrimitiveTypeName.INT32, Repetition.OPTIONAL).named("date");
+            case "TIMESTAMP":
+                return Types.primitive(PrimitiveTypeName.INT64, Repetition.OPTIONAL).named("timestamp");
+            case "STRING":
+                return Types.primitive(PrimitiveTypeName.BINARY, Repetition.OPTIONAL).named("string"); 
+            default:
+                throw new UnsupportedOperationException("Unsupported data type: " + dataType.toString());
+        }
+    }
+
+    /**
+     * Builds a map of names to Types from the read schema, the map allows
+     * easy access from a given column name to the schema {@link Type}.
+     *
+     * @param readSchema the read schema for the delta file
+     * @return a map of field names to types
+     */
+    private static Map<String, Type> getOriginalFieldsMap(StructType readSchema) {
+        Map<String, Type> readFields = new HashMap<>(readSchema.fields().size() * 2);
+
+        // We need to add the original name and lower cased name to
+        // the map to support mixed case where in GPDB the column name
+        // was created with quotes i.e "mIxEd CaSe". When quotes are not
+        // used to create a table in GPDB, the name of the column will
+        // always come in lower-case
+        readSchema.fields().forEach(t -> {
+            String columnName = t.getName();
+            readFields.put(columnName, dataTypeToParquetType(t.getDataType()));
+            readFields.put(columnName.toLowerCase(), dataTypeToParquetType(t.getDataType()));
+        });
+
+        return readFields;
+    }
+
+    private static boolean isBlank(String str) {
+        return str == null || str.trim().isEmpty();
+    }
+
+    /**
+     * Returns the parquet record filter for the given filter string
+     *
+     * @param filterString      the filter string
+     * @param originalFieldsMap a map of field names to types
+     * @return the parquet record filter for the given filter string
+     */
+    public static Predicate getFilterPredicate(String filterString, StructType readSchema,  List<ColumnDescriptor> tupleDescription) {
+        if (isBlank(filterString)) {
+            return null;
+        }
+        // Get a map of the column name to Types for the given schema
+        Map<String, Type> originalFieldsMap = getOriginalFieldsMap(readSchema);
+
+        ParquetRecordFilterBuilder filterBuilder = new ParquetRecordFilterBuilder(
+                tupleDescription, originalFieldsMap);
+        TreeVisitor pruner = new ParquetOperatorPruner(
+                tupleDescription, originalFieldsMap, ParquetRecordFilterBuilder.SUPPORTED_OPERATORS);
+        TreeVisitor bpCharTransformer = new BPCharOperatorTransformer(tupleDescription);
+
+        try {
+            // Parse the filter string into a expression tree Node
+            Node root = new FilterParser().parse(filterString);
+            // Transform IN operators into a chain of ORs, then
+            // prune the parsed tree with valid supported operators and then
+            // traverse the pruned tree with the ParquetRecordFilterBuilder to
+            // produce a record filter for parquet
+            TRAVERSER.traverse(root, IN_OPERATOR_TRANSFORMER, pruner, bpCharTransformer, filterBuilder);
+            return filterBuilder.getRecordPredicate();
+        } catch (Exception e) {
+            throw new RuntimeException("Error parsing filter string: " + filterString, e);
         }
     }
 

--- a/src/main/java/com/example/pxf/parquet/ParquetRecordFilterBuilder.java
+++ b/src/main/java/com/example/pxf/parquet/ParquetRecordFilterBuilder.java
@@ -1,0 +1,260 @@
+package com.example.pxf.parquet;
+
+import org.apache.parquet.filter2.compat.FilterCompat;
+import org.apache.parquet.filter2.predicate.FilterApi;
+import org.apache.parquet.filter2.predicate.Operators;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.DateLogicalTypeAnnotation;
+import org.apache.parquet.schema.Type;
+import org.greenplum.pxf.api.filter.ColumnIndexOperandNode;
+import org.greenplum.pxf.api.filter.Node;
+import org.greenplum.pxf.api.filter.OperandNode;
+import org.greenplum.pxf.api.filter.Operator;
+import org.greenplum.pxf.api.filter.OperatorNode;
+import org.greenplum.pxf.api.filter.TreeVisitor;
+import org.greenplum.pxf.api.utilities.ColumnDescriptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.delta.kernel.expressions.*;
+
+import java.io.ByteArrayInputStream;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.EnumSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import static org.apache.parquet.filter2.predicate.FilterApi.and;
+import static org.apache.parquet.filter2.predicate.FilterApi.binaryColumn;
+import static org.apache.parquet.filter2.predicate.FilterApi.booleanColumn;
+import static org.apache.parquet.filter2.predicate.FilterApi.doubleColumn;
+import static org.apache.parquet.filter2.predicate.FilterApi.floatColumn;
+import static org.apache.parquet.filter2.predicate.FilterApi.intColumn;
+import static org.apache.parquet.filter2.predicate.FilterApi.longColumn;
+import static org.apache.parquet.filter2.predicate.FilterApi.not;
+import static org.apache.parquet.filter2.predicate.FilterApi.or;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.DateLogicalTypeAnnotation;
+
+/**
+ * This is the implementation of {@link TreeVisitor} for Parquet.
+ * <p>
+ * The class visits all the {@link Node}s from the expression tree,
+ * and builds a simple (single {@link FilterCompat.Filter} class) for
+ * {@link org.greenplum.pxf.plugins.hdfs.ParquetFileAccessor} to use for its
+ * scan.
+ */
+public class ParquetRecordFilterBuilder implements TreeVisitor {
+
+    protected final Logger LOG = LoggerFactory.getLogger(this.getClass());
+
+    private final Map<String, Type> fields;
+    private final List<ColumnDescriptor> columnDescriptors;
+    private final Deque<Predicate> filterQueue;
+
+    public static final EnumSet<Operator> SUPPORTED_OPERATORS = EnumSet.of(
+            Operator.NOOP,
+            Operator.LESS_THAN,
+            Operator.GREATER_THAN,
+            Operator.LESS_THAN_OR_EQUAL,
+            Operator.GREATER_THAN_OR_EQUAL,
+            Operator.EQUALS,
+            Operator.NOT_EQUALS,
+            Operator.IS_NULL,
+            Operator.IS_NOT_NULL,
+            // Operator.IN,
+            Operator.OR,
+            Operator.AND,
+            Operator.NOT
+    );
+
+    /**
+     * Constructor
+     *
+     * @param columnDescriptors the list of column descriptors
+     * @param originalFields    a map of field names to types
+     */
+    public ParquetRecordFilterBuilder(List<ColumnDescriptor> columnDescriptors, Map<String, Type> originalFields) {
+        this.columnDescriptors = columnDescriptors;
+        this.filterQueue = new LinkedList<>();
+        this.fields = originalFields;
+    }
+
+    @Override
+    public Node before(Node node, int level) {
+        return node;
+    }
+
+    @Override
+    public Node visit(Node node, int level) {
+        if (node instanceof OperatorNode) {
+            OperatorNode operatorNode = (OperatorNode) node;
+            Operator operator = operatorNode.getOperator();
+            LOG.info(null == operator ? "null" : "visit node for op " + operator.toString());
+            if (!operator.isLogical()) {
+                processSimpleColumnOperator(operatorNode);
+            }
+        }
+        return node;
+    }
+
+    @Override
+    public Node after(Node node, int level) {
+        if (node instanceof OperatorNode) {
+            OperatorNode operatorNode = (OperatorNode) node;
+            Operator operator = operatorNode.getOperator();
+            if (operator.isLogical()) {
+                processLogicalOperator(operator);
+            }
+        }
+        return node;
+    }
+
+    /**
+     * Returns the built record predicate
+     *
+     * @return the built record predicate
+     */
+    public Predicate getRecordPredicate() {
+        Predicate predicate = filterQueue.poll();
+        if (!filterQueue.isEmpty()) {
+            throw new IllegalStateException("Filter queue is not empty after visiting all nodes");
+        }
+        return predicate;
+    }
+
+    private void processLogicalOperator(Operator operator) {
+        Predicate right = filterQueue.poll();
+        Predicate left = null;
+
+        if (right == null) {
+            throw new IllegalStateException("Unable to process logical operator " + operator.toString());
+        }
+
+        if (operator == Operator.AND || operator == Operator.OR) {
+            left = filterQueue.poll();
+
+            if (left == null) {
+                throw new IllegalStateException("Unable to process logical operator " + operator.toString());
+            }
+        }
+
+        switch (operator) {
+            case AND:
+                filterQueue.push(new Predicate("AND", left, right));
+                break;
+            case OR:
+                filterQueue.push(new Predicate("OR", left, right));
+                break;
+            case NOT:
+                filterQueue.push(new Predicate("NOT", right));
+                break;
+        }
+    }
+
+    private String convertOperator(Operator opt) {
+        switch (opt) {
+            case LESS_THAN:
+                return "<";
+            case GREATER_THAN:
+                return ">";
+            case LESS_THAN_OR_EQUAL:
+                return "<=";
+            case GREATER_THAN_OR_EQUAL:
+                return ">=";
+            case EQUALS:
+                return "=";
+            case NOT_EQUALS:
+                return "!=";
+            default:
+                throw new IllegalArgumentException("Unsupported operator: " + opt);
+        }
+    }
+
+    /**
+     * Handles simple column-operator-constant expressions.
+     *
+     * @param operatorNode the operator node
+     */
+    private void processSimpleColumnOperator(OperatorNode operatorNode) {
+
+        Operator operator = operatorNode.getOperator();
+        ColumnIndexOperandNode columnIndexOperand = operatorNode.getColumnIndexOperand();
+        OperandNode valueOperand = null;
+
+        if (operator != Operator.IS_NULL && operator != Operator.IS_NOT_NULL) {
+            valueOperand = operatorNode.getValueOperand();
+            if (valueOperand == null) {
+                throw new IllegalArgumentException(
+                        String.format("Operator %s does not contain an operand", operator));
+            }
+        }
+
+        ColumnDescriptor columnDescriptor = columnDescriptors.get(columnIndexOperand.index());
+        String filterColumnName = columnDescriptor.columnName();
+        Type type = fields.get(filterColumnName);
+
+        // INT96 and FIXED_LEN_BYTE_ARRAY cannot be pushed down
+        // for more details look at org.apache.parquet.filter2.dictionarylevel.DictionaryFilter#expandDictionary
+        // where INT96 and FIXED_LEN_BYTE_ARRAY are not dictionary values
+        Predicate simpleFilter;
+        switch (type.asPrimitiveType().getPrimitiveTypeName()) {
+            case INT32:
+                simpleFilter = new Predicate(convertOperator(operator), 
+                        Arrays.asList(new Column(filterColumnName), Literal.ofInt(getIntegerForINT32(type.getLogicalTypeAnnotation(), valueOperand))));
+                break;
+
+            case INT64:
+                simpleFilter = new Predicate(convertOperator(operator), 
+                        Arrays.asList(new Column(filterColumnName), Literal.ofLong(Long.parseLong(valueOperand.toString()))));
+                break;
+
+            case BINARY:
+                byte[] value = valueOperand.toString().getBytes();
+                simpleFilter = new Predicate(convertOperator(operator), 
+                        Arrays.asList(new Column(filterColumnName), Literal.ofBinary(value)));
+                break;
+
+            case BOOLEAN:
+                // Boolean does not SupportsLtGt
+                simpleFilter = new Predicate(convertOperator(operator), 
+                        Arrays.asList(new Column(filterColumnName), Literal.ofBoolean(Boolean.parseBoolean(valueOperand.toString()))));
+                break;
+
+            case FLOAT:
+                simpleFilter = new Predicate(convertOperator(operator), 
+                        Arrays.asList(new Column(filterColumnName), Literal.ofFloat(Float.parseFloat(valueOperand.toString()))));
+                break;
+
+            case DOUBLE:
+                simpleFilter = new Predicate(convertOperator(operator), 
+                        Arrays.asList(new Column(filterColumnName), Literal.ofDouble(Double.parseDouble(valueOperand.toString()))));
+                break;
+            case FIXED_LEN_BYTE_ARRAY:
+                simpleFilter = new Predicate(convertOperator(operator), 
+                        Arrays.asList(new Column(filterColumnName), Literal.ofString(valueOperand.toString())));
+                break;
+
+            default:
+                throw new UnsupportedOperationException(String.format("Column %s of type %s is not supported",
+                        type.getName(), type.asPrimitiveType().getPrimitiveTypeName()));
+        }
+
+        filterQueue.push(simpleFilter);
+    }
+
+    private static Integer getIntegerForINT32(LogicalTypeAnnotation logicalTypeAnnotation, OperandNode valueOperand) {
+        if (valueOperand == null) return null;
+        if (logicalTypeAnnotation instanceof DateLogicalTypeAnnotation) {
+            // Number of days since epoch
+            LocalDate localDateValue = LocalDate.parse(valueOperand.toString());
+            LocalDate epoch = LocalDate.ofEpochDay(0);
+            return (int) ChronoUnit.DAYS.between(epoch, localDateValue);
+        }
+        return Integer.parseInt(valueOperand.toString());
+    }
+}


### PR DESCRIPTION
1. Column Projection
    The delta table kernel API `scanBuilder.withReadSchema()` sets the columns to be read.
2. Predicate pushdown
    The delta table kernel API `scanBuilder.withFilter()` sets the scan filter. 
    Supported operators are same as Delta table API: `"<", "<=", ">", ">=", "=", "AND", "OR"`